### PR TITLE
ADT-530: Add component props to StartControllerScope return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aha-app/mvc",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Simple MVC framework using React for the view and GraphQL for the models.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/controller/ApplicationController.tsx
+++ b/src/controller/ApplicationController.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { ComponentProps, useContext, useEffect, useState } from 'react';
 import type { ComponentType, FC, ReactNode } from 'react';
 // @ts-ignore
 import { store } from '@aha-app/react-easy-state';
@@ -271,13 +271,16 @@ class ApplicationController<
  *   ...
  *   whiteboardController.current.actionPanIntoView();
  */
-function StartControllerScope<T extends ApplicationControllerConstructor<any>>(
+function StartControllerScope<
+  T extends ApplicationControllerConstructor<any>,
+  C extends ComponentType<any>
+>(
   ControllerClass: T,
-  ControlledComponent: ComponentType<Partial<GetControllerProps<T>>>
-): ComponentType<GetControllerProps<T>> {
+  ControlledComponent: C
+): ComponentType<GetControllerProps<T> & ComponentProps<C>> {
   // Use React.memo here so if props don't change then we don't re-render and
   // allocate a new controller instance.
-  return React.memo(controllerInitialArgs => {
+  return React.memo((controllerInitialArgs: any) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [controller] = useState(new ControllerClass());
 


### PR DESCRIPTION
When we use StartControllerScope the higher order component it returns accepts the props of the controller + the props of the component. Previously the **type** would only accept the controller props. This changes the return type to add the props together so typescript can see all the accepted props.