### PR TITLE
addDependency function on controllers to make it easier to add cleaned up things like events

### DIFF
--- a/src/controller/ApplicationController.tsx
+++ b/src/controller/ApplicationController.tsx
@@ -12,6 +12,7 @@ import Debug from 'debug';
 import { randomId } from '../utils/randomId';
 import CAF from 'caf';
 import { cloneDeep } from 'lodash';
+import { observe } from '..';
 
 const debug = Debug('framework:controller');
 
@@ -29,6 +30,8 @@ type GetControllerConstructor<T> = { new (): T };
 
 type GetControllerProps<T extends ApplicationControllerConstructor<any>> =
   T extends ApplicationControllerConstructor<infer P> ? P : never;
+
+export type DependencyCallback = () => void | Promise<void>;
 
 /**
  * General rules to follow for using controllers:
@@ -162,6 +165,34 @@ class ApplicationController<
    */
   internalDestroy() {
     this.destroy();
+    this.deferredDestroyCallbacks.forEach(([_name, callback]) => callback());
+    this.deferredDestroyCallbacks = [];
+  }
+
+  private deferredDestroyCallbacks: [string, DependencyCallback][] = [];
+
+  resolveDependency(name: string) {
+    const callbacks = this.deferredDestroyCallbacks.filter(([n]) => n === name);
+    callbacks.forEach(([_, callback]) => callback());
+    this.deferredDestroyCallbacks = this.deferredDestroyCallbacks.filter(([n]) => n !== name);
+  }
+
+  addDependency(name: string, callback: DependencyCallback): void;
+  addDependency(callback: DependencyCallback): void;
+  addDependency(nameOrCallback: string | DependencyCallback, callback?: DependencyCallback) {
+    if (typeof nameOrCallback === "string") {
+      if (!callback) throw new Error("Callback is required");
+      this.deferredDestroyCallbacks.push([nameOrCallback, callback]);
+    } else if (typeof nameOrCallback === "function") {
+      this.deferredDestroyCallbacks.push(["unknown", nameOrCallback]);
+    } else {
+      throw new Error("Invalid arguments");
+    }
+  }
+
+  observe(callback: () => void, options: Parameters<typeof observe>[1] = {}) {
+    const observer = observe(callback, options);
+    this.addDependency(() => observer());
   }
 
   /**


### PR DESCRIPTION
```ts
class MyController extends ApplicationController {
  initialize() {
    // Dependency callbacks can be added next to the initialization code
    document.addEventListener("keydown", handleKeyDown);
    this.addDependency(() => document.removeEventListener("keydown", handleKeyDown));

    // observe is automatically cleaned up
    this.observe(() => { console.log(this.state.someValue); });

    // Dependencies can be named so they can be trigged any time
    const connection = new Connection();
    this.addDependency("close_connection", () => connection.close());
  }

  actionClose() {
    this.resolveDependency("close_connection");
  }

  handleKeyDown = (event) => {
  }
}