### PR TITLE
Improve type definitions for ApplicationController and ApplicationView

### DIFF
--- a/src/controller/ApplicationController.tsx
+++ b/src/controller/ApplicationController.tsx
@@ -46,9 +46,9 @@ type GetControllerProps<T extends ApplicationControllerConstructor<any>> =
  *
  */
 class ApplicationController<
-  State = any,
-  Props = any,
-  Parent extends ApplicationController<any, any, any> = any
+  State extends {} = {},
+  Props extends {} = {},
+  Parent extends ApplicationController = any
 > {
   id: string;
   initialized: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,10 @@ import { raw, observable, observe, unobserve } from '@nx-js/observer-util';
 import { randomId } from './utils/randomId';
 import type { ComponentType } from 'react';
 
-function ApplicationView<C extends ComponentType>(
-  component: C
-): C;
+function ApplicationView<C extends ComponentType>(component: C): C;
 function ApplicationView<T extends {}>(
-  component: React.ComponentType<T>
-): React.ComponentType<T>;
+  component: ComponentType<T>
+): ComponentType<T>;
 
 function ApplicationView<T extends ComponentType>(component: T): T {
   return view(component);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ import { raw, observable, observe, unobserve } from '@nx-js/observer-util';
 import { randomId } from './utils/randomId';
 import type { ComponentType } from 'react';
 
+function ApplicationView<C extends ComponentType>(
+  component: C
+): C;
+function ApplicationView<T extends {}>(
+  component: React.ComponentType<T>
+): React.ComponentType<T>;
+
 function ApplicationView<T extends ComponentType>(component: T): T {
   return view(component);
 }


### PR DESCRIPTION
### ApplicationController

Having the generics default to `any` meant that if these weren't provided as arguments to the controller definition, the `any` would pollute the type hierarchy, and props from wrapped components would not be passed through. E.g. in this example, `WrappedComponent` now inherits the prop interface from `Component` correctly, where it didn't previously because `ApplicationController`'s props were typed `any`

```typescript
class ControllerA extends ApplicationController<State> {
  ...
}

const Component = (props: MyProps) = {
  ...
}

const WrappedComponent = StartControllerScope(ControllerA, Component)
```

### ApplicationView

Previously we supported the first pattern here (with types inferred correctly) but not the second. I added an overload so we now support either

```typescript
const ComponentA: React.FC<MyProps> = ApplicationView(props => {
  ...
})

const ComponentB = ApplicationView((props: MyProps) => {
  ...
})

```

