### PR TITLE
Add a text input demo and prod mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ yarn
 yarn demo
 ```
 
+To run with react in production mode
+
+```
+yarn demo:production
+```
+
 ## Running the tests
 
 Tests use [jest](https://jestjs.io/) and [testing-library](https://testing-library.com/docs/react-testing-library/intro). To run them:

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import Counter from './counter';
+import Text from './text';
 
 export const App = () => {
   return (
     <div>
       <Counter />
+      <Text />
     </div>
   );
 };

--- a/demo/text.tsx
+++ b/demo/text.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {
+  ApplicationController,
+  ApplicationView,
+  StartControllerScope,
+  useController,
+} from '../src';
+
+interface ControllerState {
+  values: Record<string, string>;
+  value?: string;
+}
+
+class TextController extends ApplicationController<ControllerState> {
+  get initialState() {
+    return { values: { a: 'Hello world' } };
+  }
+
+  actionUpdate(id: string, value: string) {
+    this.state.values[id] = value;
+  }
+}
+
+const TextInput = ApplicationView<{ id: string }>(({ id }) => {
+  const controller = useController(TextController);
+  const { values } = controller.state;
+
+  return (
+    <div style={{ margin: '0 0 10px' }}>
+      <input
+        type='text'
+        placeholder={`Value for ${id}`}
+        value={values[id] || ''}
+        onChange={e => controller.actionUpdate(id, e.target.value)}
+      />
+    </div>
+  );
+});
+
+const Text = () => {
+  const fields = ['a', 'b'];
+
+  return (
+    <div>
+      <h1>Text inputs</h1>
+
+      {fields.map(id => (
+        <TextInput id={id} key={id} />
+      ))}
+    </div>
+  );
+};
+
+export default StartControllerScope(TextController, ApplicationView(Text));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "rimraf dist && node config/build.js && tsc",
     "prepare": "yarn build",
     "test": "yarn jest",
-    "demo": "esbuild demo/index.tsx --bundle --serve --watch --outdir=demo/public --servedir=demo/public"
+    "demo": "esbuild demo/index.tsx --bundle --serve --watch --outdir=demo/public --servedir=demo/public",
+    "demo:production": "pnpm run demo --define:process.env.NODE_ENV=\\\"production\\\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds an input demo, and react prod mode to aid with reproducing bugs that only occur in production. For example - run  `yarn demo:production` and try typing into the text input - the cursor always jumps to the end