### PR TITLE
ADT-619: Provide this.observe on controllers that is auto unobserved when they are destroyed

### DIFF
--- a/tests/observe.test.tsx
+++ b/tests/observe.test.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { useState } from 'react';
+import {
+  ApplicationController,
+  ApplicationView,
+  StartControllerScope,
+  useController,
+} from '../src';
+
+interface Props {}
+
+interface State {
+  count: number;
+}
+
+class CounterController extends ApplicationController<State, Props> {
+  get initialState() {
+    return { count: 0 };
+  }
+
+  async initialize(props: Props) {
+    this.observe(() => this.storeCounterState());
+  }
+
+  actionIncrement() {
+    this.state.count += 1;
+  }
+
+  storedCounter: number;
+  storeCounterState() {
+    this.storedCounter = this.state.count;
+  }
+}
+
+let renderCountText = 0;
+
+const Counter = () => {
+  const controller = useController(CounterController);
+  const { count } = controller.state;
+
+  return (
+    <div>
+      <h1>Simple counter</h1>
+      <p className='count'>{count}</p>
+      <p>
+        <button onClick={() => controller.actionIncrement()}>+</button>
+      </p>
+    </div>
+  );
+};
+
+const ControlledCounter = StartControllerScope(
+  CounterController,
+  ApplicationView(Counter)
+);
+
+describe('observe', () => {
+  it('stops running reactions once the controller is destroyed', async () => {
+    renderCountText = 0;
+
+    let controller;
+    const { container, unmount } = render(
+      <ControlledCounter controllerRef={c => (controller = c)} />
+    );
+    const count = container.querySelector('.count');
+
+    expect(count).toHaveTextContent('0');
+    await act(async () => controller.actionIncrement());
+    expect(count).toHaveTextContent('1');
+    expect(controller.storedCounter).toBe(1);
+    unmount();
+    console.log('unmounted');
+    await act(async () => controller.actionIncrement());
+    expect(controller.storedCounter).toBe(1);
+  });
+});


### PR DESCRIPTION
- ADT-619 Add this.observe to controllers for observations that are automatically removed when the controller is destroyed.

```
class MyController extends ApplicationController {
  initailize() {
    this.observe(() => this.refreshRecords());
  }

  async refrshRecords() {
    this.state.records = await ...
  }
}
```

Observation will end when controller is unmounted