### PR TITLE
Fix jumping cursor bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 yarn-error.log
 dist/
+/playwright-report
+/test-results

--- a/e2e/cursor-position.spec.ts
+++ b/e2e/cursor-position.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Controlled Input Cursor Position', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait for React to hydrate and the text input section to be visible
+    await page.waitForSelector('h1:has-text("Text inputs")');
+  });
+
+  test('cursor position is preserved when typing in the middle of text', async ({
+    page,
+  }) => {
+    // The input "a" has initial value "Hello world"
+    const input = page.locator('input[placeholder="Value for a"]');
+
+    // Verify initial value
+    await expect(input).toHaveValue('Hello world');
+
+    // Focus the input
+    await input.focus();
+
+    // Set cursor position to middle of text (after "Hello", position 5)
+    await input.evaluate((el: HTMLInputElement) => {
+      el.setSelectionRange(5, 5);
+    });
+
+    // Verify cursor is at position 5 before typing
+    const cursorPosBefore = await input.evaluate(
+      (el: HTMLInputElement) => el.selectionStart
+    );
+    expect(cursorPosBefore).toBe(5);
+
+    // Type a single character
+    await page.keyboard.type('X');
+
+    // Wait for React to process the state update and re-render
+    // The value should now be "HelloX world"
+    await expect(input).toHaveValue('HelloX world');
+
+    // Check cursor position after typing
+    // EXPECTED (correct behavior): cursor should be at position 6 (after the X)
+    // ACTUAL (bug): cursor jumps to end (position 12)
+    const cursorPosAfter = await input.evaluate(
+      (el: HTMLInputElement) => el.selectionStart
+    );
+
+    // This assertion should FAIL initially (proving the bug exists)
+    // When the bug is fixed, cursor should be at position 6
+    expect(cursorPosAfter).toBe(6);
+  });
+
+  test('cursor does not jump to end when typing at beginning', async ({
+    page,
+  }) => {
+    const input = page.locator('input[placeholder="Value for a"]');
+
+    await expect(input).toHaveValue('Hello world');
+    await input.focus();
+
+    // Position cursor at beginning (position 0)
+    await input.evaluate((el: HTMLInputElement) => {
+      el.setSelectionRange(0, 0);
+    });
+
+    // Type at the beginning
+    await page.keyboard.type('A');
+
+    // Value should be "AHello world"
+    await expect(input).toHaveValue('AHello world');
+
+    // Cursor should be at position 1, NOT at the end (12)
+    const cursorPos = await input.evaluate(
+      (el: HTMLInputElement) => el.selectionStart
+    );
+
+    // If bug exists: cursorPos will be 12 (end of string)
+    // If fixed: cursorPos will be 1
+    expect(cursorPos).toBe(1);
+  });
+
+  test('cursor position is preserved when typing multiple characters', async ({
+    page,
+  }) => {
+    const input = page.locator('input[placeholder="Value for a"]');
+
+    await expect(input).toHaveValue('Hello world');
+    await input.focus();
+
+    // Set cursor to position 5 (after "Hello")
+    await input.evaluate((el: HTMLInputElement) => {
+      el.setSelectionRange(5, 5);
+    });
+
+    // Type multiple characters one by one
+    await page.keyboard.type('X');
+    await page.keyboard.type('Y');
+    await page.keyboard.type('Z');
+
+    // Value should be "HelloXYZ world"
+    await expect(input).toHaveValue('HelloXYZ world');
+
+    // Cursor should be at position 8 (after "HelloXYZ")
+    const cursorPos = await input.evaluate(
+      (el: HTMLInputElement) => el.selectionStart
+    );
+    expect(cursorPos).toBe(8);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@
 export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
 
   transform: {
     '^.+\\.tsx?$': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aha-app/mvc",
-  "version": "0.13.0",
+  "version": "0.14.0-rc.0",
   "description": "Simple MVC framework using React for the view and GraphQL for the models.",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "UNLICENSED",
   "homepage": "https://github.com/aha-app/mvc#readme",
   "dependencies": {
-    "@aha-app/react-easy-state": "^0.0.12-development",
+    "@nx-js/observer-util": "^4.2.2",
     "debug": "^4.1.0",
     "lodash": "^4.17.21 || npm:lodash-es@^4.17.21"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aha-app/mvc",
-  "version": "0.14.0-rc.0",
+  "version": "0.16.0-rc.0",
   "description": "Simple MVC framework using React for the view and GraphQL for the models.",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "prepare": "yarn build",
     "test": "yarn jest",
     "demo": "esbuild demo/index.tsx --bundle --serve --watch --outdir=demo/public --servedir=demo/public",
-    "demo:production": "pnpm run demo --define:process.env.NODE_ENV=\\\"production\\\""
+    "demo:production": "pnpm run demo --define:process.env.NODE_ENV=\\\"production\\\"",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "repository": {
     "type": "git",
@@ -32,6 +34,7 @@
     "react-dom": "^16.8.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+
+  use: {
+    baseURL: 'http://localhost:8000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // Start the demo server in production mode before tests
+  webServer: {
+    command: 'pnpm run demo:production',
+    url: 'http://localhost:8000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/src/controller/ApplicationController.tsx
+++ b/src/controller/ApplicationController.tsx
@@ -6,12 +6,11 @@ import React, {
   useState,
 } from 'react';
 import type { ComponentType, FC, ReactNode } from 'react';
-// @ts-ignore
-import { store } from '@aha-app/react-easy-state';
+import { store } from '../reactivity/view';
 import Debug from 'debug';
 import { randomId } from '../utils/randomId';
 import { cloneDeep } from 'lodash';
-import { observe, unobserve } from '..';
+import { observe, unobserve } from '@nx-js/observer-util';
 
 const debug = Debug('framework:controller');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,7 @@ import {
   ControlledComponent,
   useController,
 } from './controller/ApplicationController';
-// @ts-ignore
-import { view } from '@aha-app/react-easy-state';
+import { view } from './reactivity/view';
 import { raw, observable, observe, unobserve } from '@nx-js/observer-util';
 import { randomId } from './utils/randomId';
 import type { ComponentType } from 'react';

--- a/src/reactivity/view.ts
+++ b/src/reactivity/view.ts
@@ -5,7 +5,13 @@
 
 import { useState, memo, useMemo, useEffect, Component } from 'react';
 import { unstable_batchedUpdates } from 'react-dom';
-import { observe, unobserve, isObservable, raw, observable } from '@nx-js/observer-util';
+import {
+  observe,
+  unobserve,
+  isObservable,
+  raw,
+  observable,
+} from '@nx-js/observer-util';
 
 // it is window in the DOM and global in NodeJS and React Native
 
@@ -27,7 +33,10 @@ function mapStateToStores(state: any) {
   // to do not trigger none static this.setState calls
   // from the static getDerivedStateFromProps lifecycle method
   const component = state[COMPONENT];
-  return Object.keys(component).map(key => component[key]).filter(isObservable).map(raw);
+  return Object.keys(component)
+    .map(key => component[key])
+    .filter(isObservable)
+    .map(raw);
 } // We batch all updates to the view until the end of the current task. This
 // is to prevent excessive rendering in situations where updates can occur
 // outside of React's built-in batching. e.g. after resolving a promise,
@@ -35,7 +44,6 @@ function mapStateToStores(state: any) {
 //
 // NOTE: This should be revisited after React improves batching for
 // Suspense / etc.
-
 
 let batchesPending: Record<number, () => void> = {};
 let taskPending = false;
@@ -46,7 +54,9 @@ function runBatch() {
   const batchesToRun = batchesPending;
   taskPending = false;
   batchesPending = {};
-  unstable_batchedUpdates(() => Object.values(batchesToRun).forEach(setStateFn => setStateFn()));
+  unstable_batchedUpdates(() =>
+    Object.values(batchesToRun).forEach(setStateFn => setStateFn())
+  );
 }
 
 function batchSetState(viewIndex: number, fn: () => void) {
@@ -62,13 +72,11 @@ function batchSetState(viewIndex: number, fn: () => void) {
   }
 } // No need to trigger an update for this view since it has been removed.
 
-
 function clearBatch(viewIndex: number) {
   delete batchesPending[viewIndex];
 } // this creates and returns a wrapped version of the passed function
 // the cache is necessary to always map the same thing to the same function
 // which makes sure that addEventListener/removeEventListener pairs don't break
-
 
 const cache = new WeakMap();
 
@@ -93,36 +101,45 @@ function wrapFn(fn: any, wrapper: any) {
 function wrapMethodCallbacks(obj: any, method: string, wrapper: any) {
   const descriptor = Object.getOwnPropertyDescriptor(obj, method);
 
-  if (descriptor && descriptor.writable && typeof descriptor.value === 'function') {
+  if (
+    descriptor &&
+    descriptor.writable &&
+    typeof descriptor.value === 'function'
+  ) {
     obj[method] = new Proxy(descriptor.value, {
       apply(target, ctx, args) {
-        return Reflect.apply(target, ctx, args.map((f: any) => wrapFn(f, wrapper)));
-      }
-
+        return Reflect.apply(
+          target,
+          ctx,
+          args.map((f: any) => wrapFn(f, wrapper))
+        );
+      },
     });
   }
 } // wrapped obj.addEventListener(cb) like callbacks
-
 
 function wrapMethodsCallbacks(obj: any, methods: string[], wrapper: any) {
   methods.forEach(method => wrapMethodCallbacks(obj, method, wrapper));
 } // batch addEventListener calls
 
-
 if (globalObj?.EventTarget) {
-  wrapMethodsCallbacks(EventTarget.prototype, ['addEventListener', 'removeEventListener'], (fn: any, ctx: any, args: any[]) => {
-    inEventLoop = true;
+  wrapMethodsCallbacks(
+    EventTarget.prototype,
+    ['addEventListener', 'removeEventListener'],
+    (fn: any, ctx: any, args: any[]) => {
+      inEventLoop = true;
 
-    try {
-      fn.apply(ctx, args);
+      try {
+        fn.apply(ctx, args);
 
-      if (taskPending) {
-        runBatch();
+        if (taskPending) {
+          runBatch();
+        }
+      } finally {
+        inEventLoop = false;
       }
-    } finally {
-      inEventLoop = false;
     }
-  });
+  );
 }
 
 export function view(Comp: any) {
@@ -139,14 +156,18 @@ export function view(Comp: any) {
       const [, setState] = useState<object>(); // create a memoized reactive wrapper of the original component (render)
       // at the very first run of the component function
 
-      const render = useMemo(() => observe(Comp, {
-        scheduler: () => batchSetState(viewIndex, () => {
-          setState({});
-        }),
-        lazy: true
-      }), // Adding the original Comp here is necessary to make React Hot Reload work
-      // it does not affect behavior otherwise
-      [Comp]); // cleanup the reactive connections after the very last render of the component
+      const render = useMemo(
+        () =>
+          observe(Comp, {
+            scheduler: () =>
+              batchSetState(viewIndex, () => {
+                setState({});
+              }),
+            lazy: true,
+          }), // Adding the original Comp here is necessary to make React Hot Reload work
+        // it does not affect behavior otherwise
+        [Comp]
+      ); // cleanup the reactive connections after the very last render of the component
 
       useEffect(() => {
         return () => {
@@ -182,8 +203,9 @@ export function view(Comp: any) {
         this.state[COMPONENT] = this; // create a reactive render for the component
 
         this.render = observe(this.render, {
-          scheduler: () => batchSetState(this.viewIndex, () => this.setState({})),
-          lazy: true
+          scheduler: () =>
+            batchSetState(this.viewIndex, () => this.setState({})),
+          lazy: true,
         });
       }
 
@@ -192,35 +214,33 @@ export function view(Comp: any) {
         isInsideFunctionComponentWithoutHooks = isStatelessComp;
 
         try {
-          return isStatelessComp ? Comp(this.props, this.context) : super.render();
+          return isStatelessComp
+            ? Comp(this.props, this.context)
+            : super.render();
         } finally {
           isInsideClassComponentRender = false;
           isInsideFunctionComponentWithoutHooks = false;
         }
       } // react should trigger updates on prop changes, while easyState handles store changes
 
-
       shouldComponentUpdate(nextProps: any, nextState: any) {
-        const {
-          props,
-          state
-        } = this; // respect the case when the user defines a shouldComponentUpdate
+        const { props, state } = this; // respect the case when the user defines a shouldComponentUpdate
 
         if (super.shouldComponentUpdate) {
           return super.shouldComponentUpdate(nextProps, nextState);
         } // return true if it is a reactive render or state changes
 
-
         if (state !== nextState) {
           return true;
         } // the component should update if any of its props shallowly changed value
 
-
         const keys = Object.keys(props);
         const nextKeys = Object.keys(nextProps);
-        return nextKeys.length !== keys.length || nextKeys.some(key => props[key] !== nextProps[key]);
+        return (
+          nextKeys.length !== keys.length ||
+          nextKeys.some(key => props[key] !== nextProps[key])
+        );
       } // add a custom deriveStoresFromProps lifecyle method
-
 
       static getDerivedStateFromProps(props: any, state: any) {
         if ((BaseComp as any).deriveStoresFromProps) {
@@ -228,7 +248,6 @@ export function view(Comp: any) {
           const stores = mapStateToStores(state);
           (BaseComp as any).deriveStoresFromProps(props, ...stores);
         } // respect user defined getDerivedStateFromProps
-
 
         if ((BaseComp as any).getDerivedStateFromProps) {
           return (BaseComp as any).getDerivedStateFromProps(props, state);
@@ -243,12 +262,10 @@ export function view(Comp: any) {
           super.componentWillUnmount();
         } // We don't need to trigger a render.
 
-
         clearBatch(this.viewIndex); // clean up memory used by Easy State
 
         unobserve(this.render);
       }
-
     }
 
     ReactiveComp = ReactiveClassComp;
@@ -271,9 +288,11 @@ function ownKeys(object: any, enumerableOnly?: boolean) {
 
   if (Object.getOwnPropertySymbols) {
     var symbols: any = Object.getOwnPropertySymbols(object);
-    enumerableOnly && (symbols = symbols.filter(function (sym: any) {
-      return Object.getOwnPropertyDescriptor(object, sym)!.enumerable;
-    })), keys.push.apply(keys, symbols);
+    enumerableOnly &&
+      (symbols = symbols.filter(function (sym: any) {
+        return Object.getOwnPropertyDescriptor(object, sym)!.enumerable;
+      })),
+      keys.push.apply(keys, symbols);
   }
 
   return keys;
@@ -282,11 +301,22 @@ function ownKeys(object: any, enumerableOnly?: boolean) {
 function _objectSpread2(target: any, ...sources: any[]) {
   for (var i = 0; i < sources.length; i++) {
     var source = null != sources[i] ? sources[i] : {};
-    i % 2 ? ownKeys(Object(source), true).forEach(function (key) {
-      _defineProperty(target, key, source[key]);
-    }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) {
-      Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)!);
-    });
+    i % 2
+      ? ownKeys(Object(source), true).forEach(function (key) {
+          _defineProperty(target, key, source[key]);
+        })
+      : Object.getOwnPropertyDescriptors
+        ? Object.defineProperties(
+            target,
+            Object.getOwnPropertyDescriptors(source)
+          )
+        : ownKeys(Object(source)).forEach(function (key) {
+            Object.defineProperty(
+              target,
+              key,
+              Object.getOwnPropertyDescriptor(source, key)!
+            );
+          });
   }
 
   return target;
@@ -298,7 +328,7 @@ function _defineProperty(obj: any, key: string | symbol, value: any) {
       value: value,
       enumerable: true,
       configurable: true,
-      writable: true
+      writable: true,
     });
   } else {
     obj[key] = value;
@@ -330,8 +360,7 @@ const scheduler = {
 
   off() {
     scheduler.isOn = false;
-  }
-
+  },
 };
 
 // until the function is finished running
@@ -369,8 +398,7 @@ function batchFn(fn: any) {
     batched = new Proxy(fn, {
       apply(target, thisArg, args) {
         return batch(target, thisArg, args);
-      }
-
+      },
     });
     cache2.set(fn, batched);
   }
@@ -385,22 +413,20 @@ function batchMethod(obj: any, method: string) {
     return;
   }
 
-  const {
-    value,
-    writable,
-    set,
-    configurable
-  } = descriptor;
+  const { value, writable, set, configurable } = descriptor;
 
   if (configurable && typeof set === 'function') {
-    Object.defineProperty(obj, method, _objectSpread2({}, descriptor, {
-      set: batchFn(set)
-    }));
+    Object.defineProperty(
+      obj,
+      method,
+      _objectSpread2({}, descriptor, {
+        set: batchFn(set),
+      })
+    );
   } else if (writable && typeof value === 'function') {
     obj[method] = batchFn(value);
   }
 } // batches obj.onevent = fn like calls and store methods
-
 
 function batchMethods(obj: any, methods?: string[]) {
   methods = methods || Object.getOwnPropertyNames(obj);
@@ -409,7 +435,9 @@ function batchMethods(obj: any, methods?: string[]) {
 }
 
 function createStore<T extends object>(obj: T | (() => T)): T {
-  return batchMethods(observable(typeof obj === 'function' ? (obj as () => T)() : obj));
+  return batchMethods(
+    observable(typeof obj === 'function' ? (obj as () => T)() : obj)
+  );
 }
 
 export function store<T extends object>(obj: T | (() => T)): T {
@@ -424,11 +452,15 @@ export function store<T extends object>(obj: T | (() => T)): T {
   }
 
   if (isInsideFunctionComponentWithoutHooks) {
-    throw new Error('You cannot use state inside a function component with a pre-hooks version of React. Please update your React version to at least v16.8.0 to use this feature.');
+    throw new Error(
+      'You cannot use state inside a function component with a pre-hooks version of React. Please update your React version to at least v16.8.0 to use this feature.'
+    );
   }
 
   if (isInsideClassComponentRender) {
-    throw new Error('You cannot use state inside a render of a class component. Please create your store outside of the render function.');
+    throw new Error(
+      'You cannot use state inside a render of a class component. Please create your store outside of the render function.'
+    );
   }
 
   return createStore(obj);
@@ -438,22 +470,26 @@ export function autoEffect(fn: () => void, deps: any[] = []) {
   if (isInsideFunctionComponent) {
     return useEffect(() => {
       const observer = observe(fn, {
-        scheduler: () => scheduler.add(observer)
+        scheduler: () => scheduler.add(observer),
       });
       return () => unobserve(observer);
     }, deps);
   }
 
   if (isInsideFunctionComponentWithoutHooks) {
-    throw new Error('You cannot use autoEffect inside a function component with a pre-hooks version of React. Please update your React version to at least v16.8.0 to use this feature.');
+    throw new Error(
+      'You cannot use autoEffect inside a function component with a pre-hooks version of React. Please update your React version to at least v16.8.0 to use this feature.'
+    );
   }
 
   if (isInsideClassComponentRender) {
-    throw new Error('You cannot use autoEffect inside a render of a class component. Please use it in the constructor or lifecycle methods instead.');
+    throw new Error(
+      'You cannot use autoEffect inside a render of a class component. Please use it in the constructor or lifecycle methods instead.'
+    );
   }
 
   const observer = observe(fn, {
-    scheduler: () => scheduler.add(observer)
+    scheduler: () => scheduler.add(observer),
   });
   return observer;
 }

--- a/src/reactivity/view.ts
+++ b/src/reactivity/view.ts
@@ -50,6 +50,15 @@ let taskPending = false;
 let viewIndexCounter = 0;
 let inEventLoop = false;
 
+// Cursor position preservation - only tracked during input events
+interface CursorState {
+  element: HTMLInputElement | HTMLTextAreaElement;
+  start: number | null;
+  end: number | null;
+  direction: 'forward' | 'backward' | 'none' | null;
+}
+let pendingCursorRestore: CursorState | null = null;
+
 function runBatch() {
   const batchesToRun = batchesPending;
   taskPending = false;
@@ -129,14 +138,50 @@ if (globalObj?.EventTarget) {
     (fn: any, ctx: any, args: any[]) => {
       inEventLoop = true;
 
+      // Save cursor position for input/change events on text inputs
+      const event = args[0];
+      const eventType = event?.type;
+      if (eventType === 'input' || eventType === 'change') {
+        const target = event.target;
+        const tagName = target?.tagName;
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+          const inputType = tagName === 'INPUT' ? target.type : 'textarea';
+          if (
+            inputType === 'text' ||
+            inputType === 'search' ||
+            inputType === 'url' ||
+            inputType === 'tel' ||
+            inputType === 'password' ||
+            inputType === 'textarea'
+          ) {
+            pendingCursorRestore = {
+              element: target,
+              start: target.selectionStart,
+              end: target.selectionEnd,
+              direction: target.selectionDirection,
+            };
+          }
+        }
+      }
+
       try {
         fn.apply(ctx, args);
 
         if (taskPending) {
           runBatch();
+
+          // Restore cursor position after React updates
+          if (pendingCursorRestore) {
+            const { element, start, end, direction } = pendingCursorRestore;
+            if (document.activeElement === element && start !== null) {
+              element.setSelectionRange(start, end, direction || undefined);
+            }
+            pendingCursorRestore = null;
+          }
         }
       } finally {
         inEventLoop = false;
+        pendingCursorRestore = null;
       }
     }
   );

--- a/src/reactivity/view.ts
+++ b/src/reactivity/view.ts
@@ -1,0 +1,459 @@
+/**
+ * Inlined from @aha-app/react-easy-state
+ * Original source: https://github.com/RisingStack/react-easy-state
+ */
+
+import { useState, memo, useMemo, useEffect, Component } from 'react';
+import { unstable_batchedUpdates } from 'react-dom';
+import { observe, unobserve, isObservable, raw, observable } from '@nx-js/observer-util';
+
+// it is window in the DOM and global in NodeJS and React Native
+
+declare const global: typeof globalThis | undefined;
+
+const isDOM = typeof window !== 'undefined';
+const isNative = typeof global !== 'undefined';
+const globalObj: any = isDOM ? window : isNative ? global : undefined;
+const hasHooks = typeof useState === 'function';
+
+/* eslint camelcase: 0 */
+let isInsideFunctionComponent = false;
+let isInsideClassComponentRender = false;
+let isInsideFunctionComponentWithoutHooks = false;
+const COMPONENT = Symbol('owner component');
+
+function mapStateToStores(state: any) {
+  // find store properties and map them to their none observable raw value
+  // to do not trigger none static this.setState calls
+  // from the static getDerivedStateFromProps lifecycle method
+  const component = state[COMPONENT];
+  return Object.keys(component).map(key => component[key]).filter(isObservable).map(raw);
+} // We batch all updates to the view until the end of the current task. This
+// is to prevent excessive rendering in situations where updates can occur
+// outside of React's built-in batching. e.g. after resolving a promise,
+// in a setTimeout callback, in an event handler.
+//
+// NOTE: This should be revisited after React improves batching for
+// Suspense / etc.
+
+
+let batchesPending: Record<number, () => void> = {};
+let taskPending = false;
+let viewIndexCounter = 0;
+let inEventLoop = false;
+
+function runBatch() {
+  const batchesToRun = batchesPending;
+  taskPending = false;
+  batchesPending = {};
+  unstable_batchedUpdates(() => Object.values(batchesToRun).forEach(setStateFn => setStateFn()));
+}
+
+function batchSetState(viewIndex: number, fn: () => void) {
+  batchesPending[viewIndex] = fn;
+
+  if (!taskPending) {
+    taskPending = true; // If we're in an event handler, we'll run the batch at the end of it.
+
+    if (inEventLoop) return;
+    queueMicrotask(() => {
+      runBatch();
+    });
+  }
+} // No need to trigger an update for this view since it has been removed.
+
+
+function clearBatch(viewIndex: number) {
+  delete batchesPending[viewIndex];
+} // this creates and returns a wrapped version of the passed function
+// the cache is necessary to always map the same thing to the same function
+// which makes sure that addEventListener/removeEventListener pairs don't break
+
+
+const cache = new WeakMap();
+
+function wrapFn(fn: any, wrapper: any) {
+  if (typeof fn !== 'function') {
+    return fn;
+  }
+
+  let wrapped = cache.get(fn);
+
+  if (!wrapped) {
+    wrapped = function (this: any, ...args: any[]) {
+      return wrapper(fn, this, args);
+    };
+
+    cache.set(fn, wrapped);
+  }
+
+  return wrapped;
+}
+
+function wrapMethodCallbacks(obj: any, method: string, wrapper: any) {
+  const descriptor = Object.getOwnPropertyDescriptor(obj, method);
+
+  if (descriptor && descriptor.writable && typeof descriptor.value === 'function') {
+    obj[method] = new Proxy(descriptor.value, {
+      apply(target, ctx, args) {
+        return Reflect.apply(target, ctx, args.map((f: any) => wrapFn(f, wrapper)));
+      }
+
+    });
+  }
+} // wrapped obj.addEventListener(cb) like callbacks
+
+
+function wrapMethodsCallbacks(obj: any, methods: string[], wrapper: any) {
+  methods.forEach(method => wrapMethodCallbacks(obj, method, wrapper));
+} // batch addEventListener calls
+
+
+if (globalObj?.EventTarget) {
+  wrapMethodsCallbacks(EventTarget.prototype, ['addEventListener', 'removeEventListener'], (fn: any, ctx: any, args: any[]) => {
+    inEventLoop = true;
+
+    try {
+      fn.apply(ctx, args);
+
+      if (taskPending) {
+        runBatch();
+      }
+    } finally {
+      inEventLoop = false;
+    }
+  });
+}
+
+export function view(Comp: any) {
+  const isStatelessComp = !(Comp.prototype && Comp.prototype.isReactComponent);
+  let ReactiveComp: any;
+
+  if (isStatelessComp && hasHooks) {
+    // use a hook based reactive wrapper when we can
+    ReactiveComp = (props: any) => {
+      // Unique ID for each view instance.
+      viewIndexCounter += 1;
+      const viewIndex = viewIndexCounter; // use a dummy setState to update the component
+
+      const [, setState] = useState<object>(); // create a memoized reactive wrapper of the original component (render)
+      // at the very first run of the component function
+
+      const render = useMemo(() => observe(Comp, {
+        scheduler: () => batchSetState(viewIndex, () => {
+          setState({});
+        }),
+        lazy: true
+      }), // Adding the original Comp here is necessary to make React Hot Reload work
+      // it does not affect behavior otherwise
+      [Comp]); // cleanup the reactive connections after the very last render of the component
+
+      useEffect(() => {
+        return () => {
+          // We don't need to trigger a render after the component is removed.
+          clearBatch(viewIndex);
+          unobserve(render);
+        };
+      }, []); // the isInsideFunctionComponent flag is used to toggle `store` behavior
+      // based on where it was called from
+
+      isInsideFunctionComponent = true;
+
+      try {
+        // run the reactive render instead of the original one
+        return render(props);
+      } finally {
+        isInsideFunctionComponent = false;
+      }
+    };
+  } else {
+    const BaseComp: any = isStatelessComp ? Component : Comp; // a HOC which overwrites render, shouldComponentUpdate and componentWillUnmount
+    // it decides when to run the new reactive methods and when to proxy to the original methods
+
+    class ReactiveClassComp extends BaseComp {
+      viewIndex: number;
+
+      constructor(props: any, context: any) {
+        super(props, context); // Unique ID for each class insance.
+
+        viewIndexCounter += 1;
+        this.viewIndex = viewIndexCounter;
+        this.state = this.state || {};
+        this.state[COMPONENT] = this; // create a reactive render for the component
+
+        this.render = observe(this.render, {
+          scheduler: () => batchSetState(this.viewIndex, () => this.setState({})),
+          lazy: true
+        });
+      }
+
+      render() {
+        isInsideClassComponentRender = !isStatelessComp;
+        isInsideFunctionComponentWithoutHooks = isStatelessComp;
+
+        try {
+          return isStatelessComp ? Comp(this.props, this.context) : super.render();
+        } finally {
+          isInsideClassComponentRender = false;
+          isInsideFunctionComponentWithoutHooks = false;
+        }
+      } // react should trigger updates on prop changes, while easyState handles store changes
+
+
+      shouldComponentUpdate(nextProps: any, nextState: any) {
+        const {
+          props,
+          state
+        } = this; // respect the case when the user defines a shouldComponentUpdate
+
+        if (super.shouldComponentUpdate) {
+          return super.shouldComponentUpdate(nextProps, nextState);
+        } // return true if it is a reactive render or state changes
+
+
+        if (state !== nextState) {
+          return true;
+        } // the component should update if any of its props shallowly changed value
+
+
+        const keys = Object.keys(props);
+        const nextKeys = Object.keys(nextProps);
+        return nextKeys.length !== keys.length || nextKeys.some(key => props[key] !== nextProps[key]);
+      } // add a custom deriveStoresFromProps lifecyle method
+
+
+      static getDerivedStateFromProps(props: any, state: any) {
+        if ((BaseComp as any).deriveStoresFromProps) {
+          // inject all local stores and let the user mutate them directly
+          const stores = mapStateToStores(state);
+          (BaseComp as any).deriveStoresFromProps(props, ...stores);
+        } // respect user defined getDerivedStateFromProps
+
+
+        if ((BaseComp as any).getDerivedStateFromProps) {
+          return (BaseComp as any).getDerivedStateFromProps(props, state);
+        }
+
+        return null;
+      }
+
+      componentWillUnmount() {
+        // call user defined componentWillUnmount
+        if (super.componentWillUnmount) {
+          super.componentWillUnmount();
+        } // We don't need to trigger a render.
+
+
+        clearBatch(this.viewIndex); // clean up memory used by Easy State
+
+        unobserve(this.render);
+      }
+
+    }
+
+    ReactiveComp = ReactiveClassComp;
+  }
+
+  ReactiveComp.displayName = Comp.displayName || Comp.name; // static props are inherited by class components,
+  // but have to be copied for function components
+
+  if (isStatelessComp) {
+    Object.keys(Comp).forEach(key => {
+      ReactiveComp[key] = Comp[key];
+    });
+  }
+
+  return isStatelessComp && hasHooks ? memo(ReactiveComp) : ReactiveComp;
+}
+
+function ownKeys(object: any, enumerableOnly?: boolean) {
+  var keys = Object.keys(object);
+
+  if (Object.getOwnPropertySymbols) {
+    var symbols: any = Object.getOwnPropertySymbols(object);
+    enumerableOnly && (symbols = symbols.filter(function (sym: any) {
+      return Object.getOwnPropertyDescriptor(object, sym)!.enumerable;
+    })), keys.push.apply(keys, symbols);
+  }
+
+  return keys;
+}
+
+function _objectSpread2(target: any, ...sources: any[]) {
+  for (var i = 0; i < sources.length; i++) {
+    var source = null != sources[i] ? sources[i] : {};
+    i % 2 ? ownKeys(Object(source), true).forEach(function (key) {
+      _defineProperty(target, key, source[key]);
+    }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) {
+      Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)!);
+    });
+  }
+
+  return target;
+}
+
+function _defineProperty(obj: any, key: string | symbol, value: any) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
+  }
+
+  return obj;
+}
+
+const taskQueue = new Set<() => void>();
+const scheduler = {
+  isOn: false,
+
+  add(task: () => void) {
+    if (scheduler.isOn) {
+      taskQueue.add(task);
+    } else {
+      task();
+    }
+  },
+
+  flush() {
+    taskQueue.forEach(task => task());
+    taskQueue.clear();
+  },
+
+  on() {
+    scheduler.isOn = true;
+  },
+
+  off() {
+    scheduler.isOn = false;
+  }
+
+};
+
+// until the function is finished running
+// react renders are batched by unstable_batchedUpdates
+// autoEffects and other custom reactions are batched by our scheduler
+
+function batch(fn: any, ctx: any, args: any[]) {
+  // do not apply scheduler logic if it is already applied from a parent function
+  // it would flush in the middle of the parent's batch
+  if (scheduler.isOn) {
+    return unstable_batchedUpdates(() => fn.apply(ctx, args));
+  }
+
+  try {
+    scheduler.on();
+    return unstable_batchedUpdates(() => fn.apply(ctx, args));
+  } finally {
+    scheduler.flush();
+    scheduler.off();
+  }
+} // this creates and returns a batched version of the passed function
+// the cache is necessary to always map the same thing to the same function
+// which makes sure that addEventListener/removeEventListener pairs don't break
+
+const cache2 = new WeakMap();
+
+function batchFn(fn: any) {
+  if (typeof fn !== 'function') {
+    return fn;
+  }
+
+  let batched = cache2.get(fn);
+
+  if (!batched) {
+    batched = new Proxy(fn, {
+      apply(target, thisArg, args) {
+        return batch(target, thisArg, args);
+      }
+
+    });
+    cache2.set(fn, batched);
+  }
+
+  return batched;
+}
+
+function batchMethod(obj: any, method: string) {
+  const descriptor = Object.getOwnPropertyDescriptor(obj, method);
+
+  if (!descriptor) {
+    return;
+  }
+
+  const {
+    value,
+    writable,
+    set,
+    configurable
+  } = descriptor;
+
+  if (configurable && typeof set === 'function') {
+    Object.defineProperty(obj, method, _objectSpread2({}, descriptor, {
+      set: batchFn(set)
+    }));
+  } else if (writable && typeof value === 'function') {
+    obj[method] = batchFn(value);
+  }
+} // batches obj.onevent = fn like calls and store methods
+
+
+function batchMethods(obj: any, methods?: string[]) {
+  methods = methods || Object.getOwnPropertyNames(obj);
+  methods.forEach(method => batchMethod(obj, method));
+  return obj;
+}
+
+function createStore<T extends object>(obj: T | (() => T)): T {
+  return batchMethods(observable(typeof obj === 'function' ? (obj as () => T)() : obj));
+}
+
+export function store<T extends object>(obj: T | (() => T)): T {
+  // do not create new versions of the store on every render
+  // if it is a local store in a function component
+  // create a memoized store at the first call instead
+  if (isInsideFunctionComponent) {
+    // useMemo is not a semantic guarantee
+    // In the future, React may choose to "forget" some previously memoized values and recalculate them on next render
+    // see this docs for more explanation: https://reactjs.org/docs/hooks-reference.html#usememo
+    return useMemo(() => createStore(obj), []);
+  }
+
+  if (isInsideFunctionComponentWithoutHooks) {
+    throw new Error('You cannot use state inside a function component with a pre-hooks version of React. Please update your React version to at least v16.8.0 to use this feature.');
+  }
+
+  if (isInsideClassComponentRender) {
+    throw new Error('You cannot use state inside a render of a class component. Please create your store outside of the render function.');
+  }
+
+  return createStore(obj);
+}
+
+export function autoEffect(fn: () => void, deps: any[] = []) {
+  if (isInsideFunctionComponent) {
+    return useEffect(() => {
+      const observer = observe(fn, {
+        scheduler: () => scheduler.add(observer)
+      });
+      return () => unobserve(observer);
+    }, deps);
+  }
+
+  if (isInsideFunctionComponentWithoutHooks) {
+    throw new Error('You cannot use autoEffect inside a function component with a pre-hooks version of React. Please update your React version to at least v16.8.0 to use this feature.');
+  }
+
+  if (isInsideClassComponentRender) {
+    throw new Error('You cannot use autoEffect inside a render of a class component. Please use it in the constructor or lifecycle methods instead.');
+  }
+
+  const observer = observe(fn, {
+    scheduler: () => scheduler.add(observer)
+  });
+  return observer;
+}

--- a/src/reactivity/view.ts
+++ b/src/reactivity/view.ts
@@ -3,7 +3,7 @@
  * Original source: https://github.com/RisingStack/react-easy-state
  */
 
-import { useState, memo, useMemo, useEffect, Component } from 'react';
+import { useState, memo, useMemo, useEffect, useLayoutEffect, useRef, Component } from 'react';
 import { unstable_batchedUpdates } from 'react-dom';
 import { observe, unobserve, isObservable, raw, observable } from '@nx-js/observer-util';
 
@@ -65,7 +65,56 @@ function batchSetState(viewIndex: number, fn: () => void) {
 
 function clearBatch(viewIndex: number) {
   delete batchesPending[viewIndex];
-} // this creates and returns a wrapped version of the passed function
+}
+
+// Cursor position preservation for controlled inputs
+interface CursorPosition {
+  element: HTMLInputElement | HTMLTextAreaElement;
+  start: number | null;
+  end: number | null;
+  direction: 'forward' | 'backward' | 'none' | null;
+}
+
+function saveCursorPosition(): CursorPosition | null {
+  if (typeof document === 'undefined') return null;
+  const activeElement = document.activeElement;
+  if (
+    activeElement &&
+    (activeElement instanceof HTMLInputElement ||
+      activeElement instanceof HTMLTextAreaElement)
+  ) {
+    const type = activeElement instanceof HTMLInputElement ? activeElement.type : 'textarea';
+    if (['text', 'search', 'url', 'tel', 'password', 'textarea'].includes(type)) {
+      return {
+        element: activeElement,
+        start: activeElement.selectionStart,
+        end: activeElement.selectionEnd,
+        direction: activeElement.selectionDirection,
+      };
+    }
+  }
+  return null;
+}
+
+function restoreCursorPosition(saved: CursorPosition | null) {
+  if (
+    saved &&
+    document.activeElement === saved.element &&
+    saved.start !== null
+  ) {
+    try {
+      saved.element.setSelectionRange(
+        saved.start,
+        saved.end,
+        saved.direction || undefined
+      );
+    } catch {
+      // Some input types don't support setSelectionRange
+    }
+  }
+}
+
+// this creates and returns a wrapped version of the passed function
 // the cache is necessary to always map the same thing to the same function
 // which makes sure that addEventListener/removeEventListener pairs don't break
 
@@ -139,10 +188,19 @@ export function view(Comp: any) {
       const [, setState] = useState<object>(); // create a memoized reactive wrapper of the original component (render)
       // at the very first run of the component function
 
+      // Ref to store cursor position before re-render
+      const cursorRef = useRef<CursorPosition | null>(null);
+
       const render = useMemo(() => observe(Comp, {
-        scheduler: () => batchSetState(viewIndex, () => {
-          setState({});
-        }),
+        scheduler: () => {
+          // Save cursor position IMMEDIATELY when observable triggers,
+          // before any batching delays. This captures the cursor position
+          // right after the user's input event, before React re-renders.
+          cursorRef.current = saveCursorPosition();
+          batchSetState(viewIndex, () => {
+            setState({});
+          });
+        },
         lazy: true
       }), // Adding the original Comp here is necessary to make React Hot Reload work
       // it does not affect behavior otherwise
@@ -154,7 +212,15 @@ export function view(Comp: any) {
           clearBatch(viewIndex);
           unobserve(render);
         };
-      }, []); // the isInsideFunctionComponent flag is used to toggle `store` behavior
+      }, []);
+
+      // Restore cursor position after DOM updates
+      useLayoutEffect(() => {
+        restoreCursorPosition(cursorRef.current);
+        cursorRef.current = null;
+      });
+
+      // the isInsideFunctionComponent flag is used to toggle `store` behavior
       // based on where it was called from
 
       isInsideFunctionComponent = true;
@@ -172,6 +238,7 @@ export function view(Comp: any) {
 
     class ReactiveClassComp extends BaseComp {
       viewIndex: number;
+      cursorPosition: CursorPosition | null = null;
 
       constructor(props: any, context: any) {
         super(props, context); // Unique ID for each class insance.
@@ -182,9 +249,21 @@ export function view(Comp: any) {
         this.state[COMPONENT] = this; // create a reactive render for the component
 
         this.render = observe(this.render, {
-          scheduler: () => batchSetState(this.viewIndex, () => this.setState({})),
+          scheduler: () => {
+            // Save cursor position IMMEDIATELY when observable triggers
+            this.cursorPosition = saveCursorPosition();
+            batchSetState(this.viewIndex, () => this.setState({}));
+          },
           lazy: true
         });
+      }
+
+      componentDidUpdate() {
+        restoreCursorPosition(this.cursorPosition);
+        this.cursorPosition = null;
+        if (super.componentDidUpdate) {
+          super.componentDidUpdate();
+        }
       }
 
       render() {

--- a/src/reactivity/view.ts
+++ b/src/reactivity/view.ts
@@ -3,7 +3,7 @@
  * Original source: https://github.com/RisingStack/react-easy-state
  */
 
-import { useState, memo, useMemo, useEffect, useLayoutEffect, useRef, Component } from 'react';
+import { useState, memo, useMemo, useEffect, Component } from 'react';
 import { unstable_batchedUpdates } from 'react-dom';
 import { observe, unobserve, isObservable, raw, observable } from '@nx-js/observer-util';
 
@@ -65,56 +65,7 @@ function batchSetState(viewIndex: number, fn: () => void) {
 
 function clearBatch(viewIndex: number) {
   delete batchesPending[viewIndex];
-}
-
-// Cursor position preservation for controlled inputs
-interface CursorPosition {
-  element: HTMLInputElement | HTMLTextAreaElement;
-  start: number | null;
-  end: number | null;
-  direction: 'forward' | 'backward' | 'none' | null;
-}
-
-function saveCursorPosition(): CursorPosition | null {
-  if (typeof document === 'undefined') return null;
-  const activeElement = document.activeElement;
-  if (
-    activeElement &&
-    (activeElement instanceof HTMLInputElement ||
-      activeElement instanceof HTMLTextAreaElement)
-  ) {
-    const type = activeElement instanceof HTMLInputElement ? activeElement.type : 'textarea';
-    if (['text', 'search', 'url', 'tel', 'password', 'textarea'].includes(type)) {
-      return {
-        element: activeElement,
-        start: activeElement.selectionStart,
-        end: activeElement.selectionEnd,
-        direction: activeElement.selectionDirection,
-      };
-    }
-  }
-  return null;
-}
-
-function restoreCursorPosition(saved: CursorPosition | null) {
-  if (
-    saved &&
-    document.activeElement === saved.element &&
-    saved.start !== null
-  ) {
-    try {
-      saved.element.setSelectionRange(
-        saved.start,
-        saved.end,
-        saved.direction || undefined
-      );
-    } catch {
-      // Some input types don't support setSelectionRange
-    }
-  }
-}
-
-// this creates and returns a wrapped version of the passed function
+} // this creates and returns a wrapped version of the passed function
 // the cache is necessary to always map the same thing to the same function
 // which makes sure that addEventListener/removeEventListener pairs don't break
 
@@ -188,19 +139,10 @@ export function view(Comp: any) {
       const [, setState] = useState<object>(); // create a memoized reactive wrapper of the original component (render)
       // at the very first run of the component function
 
-      // Ref to store cursor position before re-render
-      const cursorRef = useRef<CursorPosition | null>(null);
-
       const render = useMemo(() => observe(Comp, {
-        scheduler: () => {
-          // Save cursor position IMMEDIATELY when observable triggers,
-          // before any batching delays. This captures the cursor position
-          // right after the user's input event, before React re-renders.
-          cursorRef.current = saveCursorPosition();
-          batchSetState(viewIndex, () => {
-            setState({});
-          });
-        },
+        scheduler: () => batchSetState(viewIndex, () => {
+          setState({});
+        }),
         lazy: true
       }), // Adding the original Comp here is necessary to make React Hot Reload work
       // it does not affect behavior otherwise
@@ -212,15 +154,7 @@ export function view(Comp: any) {
           clearBatch(viewIndex);
           unobserve(render);
         };
-      }, []);
-
-      // Restore cursor position after DOM updates
-      useLayoutEffect(() => {
-        restoreCursorPosition(cursorRef.current);
-        cursorRef.current = null;
-      });
-
-      // the isInsideFunctionComponent flag is used to toggle `store` behavior
+      }, []); // the isInsideFunctionComponent flag is used to toggle `store` behavior
       // based on where it was called from
 
       isInsideFunctionComponent = true;
@@ -238,7 +172,6 @@ export function view(Comp: any) {
 
     class ReactiveClassComp extends BaseComp {
       viewIndex: number;
-      cursorPosition: CursorPosition | null = null;
 
       constructor(props: any, context: any) {
         super(props, context); // Unique ID for each class insance.
@@ -249,21 +182,9 @@ export function view(Comp: any) {
         this.state[COMPONENT] = this; // create a reactive render for the component
 
         this.render = observe(this.render, {
-          scheduler: () => {
-            // Save cursor position IMMEDIATELY when observable triggers
-            this.cursorPosition = saveCursorPosition();
-            batchSetState(this.viewIndex, () => this.setState({}));
-          },
+          scheduler: () => batchSetState(this.viewIndex, () => this.setState({})),
           lazy: true
         });
-      }
-
-      componentDidUpdate() {
-        restoreCursorPosition(this.cursorPosition);
-        this.cursorPosition = null;
-        if (super.componentDidUpdate) {
-          super.componentDidUpdate();
-        }
       }
 
       render() {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,361 @@
+// src/controller/ApplicationController.tsx
+import React, { useContext, useEffect, useState } from 'react';
+import { store } from '@aha-app/react-easy-state';
+import Debug from 'debug';
+
+// src/utils/randomId.ts
+var add = function (x, y, base) {
+  const z = [];
+  const n = Math.max(x.length, y.length);
+  let carry = 0;
+  let i = 0;
+  while (i < n || carry) {
+    const xi = i < x.length ? x[i] : 0;
+    const yi = i < y.length ? y[i] : 0;
+    const zi = carry + xi + yi;
+    z.push(zi % base);
+    carry = Math.floor(zi / base);
+    i++;
+  }
+  return z;
+};
+var multiplyByNumber = function (num, x, base) {
+  if (num < 0) {
+    return null;
+  }
+  if (num === 0) {
+    return [];
+  }
+  let result = [];
+  let power = x;
+  while (true) {
+    if (num & 1) {
+      result = add(result, power, base);
+    }
+    num = num >> 1;
+    if (num === 0) {
+      break;
+    }
+    power = add(power, power, base);
+  }
+  return result;
+};
+var parseToDigitsArray = function (str, base) {
+  const digits = str.split('');
+  const ary = [];
+  let i = digits.length - 1;
+  while (i >= 0) {
+    const n = parseInt(digits[i], base);
+    if (isNaN(n)) {
+      return null;
+    }
+    ary.push(n);
+    i--;
+  }
+  return ary;
+};
+var convertBase = function (str, fromBase, toBase) {
+  const digits = parseToDigitsArray(str, fromBase);
+  if (digits === null) {
+    return null;
+  }
+  let outArray = [];
+  let power = [1];
+  let i = 0;
+  while (i < digits.length) {
+    if (digits[i]) {
+      outArray = add(
+        outArray,
+        multiplyByNumber(digits[i], power, toBase),
+        toBase
+      );
+    }
+    power = multiplyByNumber(fromBase, power, toBase);
+    i++;
+  }
+  let out = '';
+  i = outArray.length - 1;
+  while (i >= 0) {
+    out += outArray[i].toString(toBase);
+    i--;
+  }
+  return out;
+};
+var randomId = function () {
+  const time = /* @__PURE__ */ new Date();
+  const now = Math.round((time.getTime() / 1e3) * 256);
+  const now_low = now & 4294967295;
+  const now_high = (now - now_low) / 4294967296 - 1;
+  const num = [];
+  num[0] = (now_high >> 0) & 255;
+  num[1] = (now_low >> 24) & 255;
+  num[2] = (now_low >> 16) & 255;
+  num[3] = (now_low >> 8) & 255;
+  num[4] = (now_low >> 0) & 255;
+  num[5] = Math.floor(Math.random() * 255);
+  num[6] = Math.floor(Math.random() * 255);
+  num[7] = Math.floor(Math.random() * 255);
+  let hex = '';
+  let _i = 0;
+  const _len = num.length;
+  while (_i < _len) {
+    const n = num[_i];
+    const h = n.toString(16);
+    if (n < 16) {
+      hex = `${hex}0${h}`;
+    } else {
+      hex = hex + h;
+    }
+    _i++;
+  }
+  return convertBase(hex, 16, 10);
+};
+
+// src/controller/ApplicationController.tsx
+import { cloneDeep } from 'lodash';
+var debug = Debug('framework:controller');
+var ControllerNoActionError = class extends Error {};
+var ApplicationController = class {
+  constructor() {
+    this._debug = Debug(`controller:${this.constructor.name}`);
+    this.id = randomId();
+    this.initialized = false;
+    this.parent = null;
+    this.state = void 0;
+    this.proxiedThis = new Proxy(this, {
+      // Traverse up through the controller hierarchy and find one that responds
+      // to the specified action.
+      get(targetController, prop, receiver) {
+        if (typeof prop === 'string' && prop.startsWith('action')) {
+          let currentController = targetController;
+          let currentProxy = receiver;
+          do {
+            if (prop in currentController) {
+              return function (...args) {
+                return currentController[prop](...args);
+              };
+            }
+            currentController = currentController.parent;
+            currentProxy = currentProxy.parent;
+          } while (currentController);
+          throw new ControllerNoActionError(
+            `Unable to find an action ${prop} on ${targetController.constructor.name}`
+          );
+        } else {
+          return Reflect.get(targetController, prop, receiver);
+        }
+      },
+      has(targetController, prop) {
+        if (typeof prop === 'string' && prop.startsWith('action')) {
+          return !!targetController.findController(
+            controller => prop in controller
+          );
+        } else {
+          return Reflect.has(targetController, prop);
+        }
+      },
+    });
+    return this.proxiedThis;
+  }
+  /**
+   * Controllers can override this method to initialize at mount with the
+   * original props passed to the controller wrapped component.
+   *
+   * @abstract
+   */
+  async initialize(props) {}
+  /**
+   * Internal initializer function
+   *
+   * @hidden
+   */
+  internalInitialize(parentController, initialArgs) {
+    if (!this.initialized) {
+      this.parent = parentController;
+      debug(
+        `Initializing ${this.constructor.name}${parentController ? ' > ' + parentController.constructor.name : ''}`
+      );
+      this.props = store({ ...initialArgs });
+      this.state = store(cloneDeep(this.initialState));
+      if (this.initialize) this.initialize(initialArgs);
+      this.initialized = true;
+    } else {
+      const oldProps = { ...this.props };
+      Object.keys(initialArgs).forEach(key => {
+        if (this.props[key] !== initialArgs[key]) {
+          this.props[key] = initialArgs[key];
+        }
+      });
+      this.changeProps(initialArgs, oldProps);
+    }
+  }
+  /**
+   * Controllers can override this method to cleanup when removed
+   */
+  destroy() {}
+  /**
+   * Creates the initial state of the controller.
+   */
+  get initialState() {
+    if ('initialState' in this.constructor) {
+      return this.constructor.initialState;
+    }
+    return {};
+  }
+  /**
+   * Internal destroy function. Do not override
+   * @private
+   */
+  internalDestroy() {
+    this.destroy();
+  }
+  /**
+   * Finds a controller in this controller's hierarchy that matches a finder.
+   */
+  findController(finder) {
+    let controller = this;
+    do {
+      if (finder(controller)) {
+        return controller;
+      }
+      controller = controller.parent;
+    } while (controller);
+  }
+  findControllerInstance(controllerClass) {
+    return this.findController(
+      _controller => _controller instanceof controllerClass
+    );
+  }
+  /**
+   * Force a record to be an observed instance that will
+   * trigger observers on the controller state.
+   *
+   * You need this if you're using `.save()` to create a
+   * record and want the updated record to trigger state updates.
+   *
+   * @deprecated just use observable() directly, no need for _tempObservable.
+   */
+  observable(obj) {
+    this.state._tempObservable = obj;
+    return this.state._tempObservable;
+  }
+  /**
+   * Override in controller class to respond to changes in props
+   *
+   * @abstract
+   */
+  changeProps(newProps, oldProps) {}
+  /**
+   * Partially set state
+   */
+  setState(newState) {
+    Object.keys(newState).forEach(key => {
+      this.state[key] = newState[key];
+    });
+  }
+  /**
+   * Extends instances of this controller with the properties defined in
+   * `mixin`. Will overwrite any existing properties of the same name.
+   */
+  static extend(mixin) {
+    Object.keys(mixin).forEach(key => {
+      const descriptor = Object.getOwnPropertyDescriptor(mixin, key);
+      Object.defineProperty(this.prototype, key, descriptor);
+    });
+  }
+  /**
+   * Output to debugger with the controller name. Set localStorage.debug to
+   * 'controller:*' or 'controller:MyController' to see debug output.
+   *
+   * @param args messages to log
+   */
+  debug(formatter, ...args) {
+    this._debug(formatter, ...args);
+  }
+};
+function StartControllerScope(ControllerClass, ControlledComponent2) {
+  return React.memo(controllerInitialArgs => {
+    const [controller] = useState(new ControllerClass());
+    if (
+      controllerInitialArgs == null
+        ? void 0
+        : controllerInitialArgs.controllerRef
+    ) {
+      if (typeof controllerInitialArgs.controllerRef === 'function') {
+        controllerInitialArgs.controllerRef(controller);
+      } else if (
+        controllerInitialArgs.controllerRef.hasOwnProperty('current')
+      ) {
+        controllerInitialArgs.controllerRef.current = controller;
+      } else {
+        throw new Error(
+          'The controllerRef prop must be passed the value provided by useRef() or useCallback().'
+        );
+      }
+    }
+    return /* @__PURE__ */ React.createElement(
+      Controller,
+      {
+        controller,
+        controllerInitialArgs,
+        key: controller.id,
+      },
+      /* @__PURE__ */ React.createElement(ControlledComponent2, {
+        ...controllerInitialArgs,
+      })
+    );
+  });
+}
+var ControllerContext = React.createContext(null);
+function Controller({ children, controller, controllerInitialArgs }) {
+  const parentController = useContext(ControllerContext);
+  controller.internalInitialize(parentController, controllerInitialArgs);
+  useEffect(() => {
+    return () => {
+      debug('Destroying controller');
+      controller.internalDestroy();
+    };
+  }, [controller]);
+  return /* @__PURE__ */ React.createElement(
+    ControllerContext.Provider,
+    { value: controller },
+    children
+  );
+}
+var ControlledComponent = ({ children, controller }) => {
+  return /* @__PURE__ */ React.createElement(
+    ControllerContext.Provider,
+    { value: controller },
+    children
+  );
+};
+function useController(controllerClass = void 0) {
+  let controller = useContext(ControllerContext);
+  if (controllerClass) {
+    controller = controller.findControllerInstance(controllerClass);
+  }
+  const statefulController = controller;
+  return statefulController;
+}
+
+// src/index.ts
+import { view } from '@aha-app/react-easy-state';
+import { raw, observable, observe, unobserve } from '@nx-js/observer-util';
+function ApplicationView(component) {
+  return view(component);
+}
+var src_default = ApplicationController;
+export {
+  ApplicationController,
+  ApplicationView,
+  ControlledComponent,
+  StartControllerScope,
+  src_default as default,
+  observable,
+  observe,
+  randomId,
+  raw,
+  unobserve,
+  useController,
+};
+//# sourceMappingURL=index.js.map

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,13 +7,6 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.2.tgz#a6abc715fb6884851fca9dad37fc34739a04fd11"
   integrity sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==
 
-"@aha-app/react-easy-state@^0.0.12-development":
-  version "0.0.12-development"
-  resolved "https://registry.yarnpkg.com/@aha-app/react-easy-state/-/react-easy-state-0.0.12-development.tgz#a4c2b19cfb3a52a83622e2a1fff1f88fedb40c2f"
-  integrity sha512-V18+9yvg4QmgJfhFsDk9VrzSSXlyKlzNOiYAZtMmatPFcRCVbwuL2mWknvBhweEoto7Hq+ONwxpHEuX3beQYpQ==
-  dependencies:
-    "@nx-js/observer-util" "^4.3.0-alpha.2"
-
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -701,10 +694,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@nx-js/observer-util@^4.3.0-alpha.2":
-  version "4.3.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@nx-js/observer-util/-/observer-util-4.3.0-alpha.2.tgz#0eaf0029860e19f26ac9721b1f53eb6fc91ebdda"
-  integrity sha512-15oX1btB2VAKHXEDJWLr4+DlmFhPTP2OHXIwjIgWhBhsZg8XjuyO1obqp/vOEHcia7HARJ2cNRyYZTDpOIsgZQ==
+"@nx-js/observer-util@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@nx-js/observer-util/-/observer-util-4.2.2.tgz#faea1bc61936653486d1b5dec7485220991e628d"
+  integrity sha512-9OayX1xkdGjdnsDiO2YdaYJ6aMyCF7/NY4QWVgIgjSAZJ4OX2fD766Ts79hEzBscenQy2DCaSoY8VkguIMB1ZA==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,6 +711,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.58.2":
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
+  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+  dependencies:
+    playwright "1.58.2"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -1684,6 +1691,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@^2.3.2:
   version "2.3.3"
@@ -2860,6 +2872,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
+  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+
+playwright@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
+  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+  dependencies:
+    playwright-core "1.58.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 prettier@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
In production react, when mvc state provides the value to a controlled input, the cursor jumps to the end on every keystroke. This only happens in production, not development, due to React's batching behaviour. Repro with `yarn demo:production`

https://github.com/user-attachments/assets/b3f217ac-582f-4678-8f28-13f39bc48500

This PR

1. Adds a playwright test suite to reproduce the problem
2. Inlines https://github.com/aha-app/react-easy-state which is not used anywhere else
3. Fixes the problem by saving and restoring the cursor position in the view code

The actual fix is in https://github.com/aha-app/mvc/pull/20/changes/eb145bcaf890a94be1994c10b9f1010fbbe068f0